### PR TITLE
bump up gephi toolkit for 0.9.3->0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.gephi</groupId>
     <artifactId>toolkit-demos</artifactId>
-    <version>0.9.3</version>
+    <version>0.10.0</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/org/gephi/toolkit/demos/Filtering.java
+++ b/src/main/java/org/gephi/toolkit/demos/Filtering.java
@@ -100,7 +100,7 @@ public class Filtering {
         System.out.println("Nodes: " + graph.getNodeCount() + " Edges: " + graph.getEdgeCount());
 
         //Filter, keep partition 'Blogarama'. Build partition with 'source' column in the data
-        NodePartitionFilter partitionFilter = new NodePartitionFilter(appearanceModel.getNodePartition(graphModel.getNodeTable().getColumn("source")));
+        NodePartitionFilter partitionFilter = new NodePartitionFilter(appearanceModel,appearanceModel.getNodePartition(graphModel.getNodeTable().getColumn("source")));
         partitionFilter.unselectAll();
         partitionFilter.addPart("Blogarama");
         Query query2 = filterController.createQuery(partitionFilter);

--- a/src/main/java/org/gephi/toolkit/demos/ImportExport.java
+++ b/src/main/java/org/gephi/toolkit/demos/ImportExport.java
@@ -20,7 +20,7 @@ along with Gephi.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.gephi.toolkit.demos;
 
-import com.itextpdf.text.PageSize;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -107,7 +107,7 @@ public class ImportExport {
 
         //PDF Exporter config and export to Byte array
         PDFExporter pdfExporter = (PDFExporter) ec.getExporter("pdf");
-        pdfExporter.setPageSize(PageSize.A0);
+        pdfExporter.setPageSize(PDRectangle.A0);
         pdfExporter.setWorkspace(workspace);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ec.exportStream(baos, pdfExporter);


### PR DESCRIPTION
# overview

bump up for gephi toolkit version 0.9.3 to 0.10.0

# Build

```
mvn compile
mvn test
JDK_JAVA_OPTIONS="--add-opens=java.base/java.net=ALL-UNNAMED" mvn exec:java -Dexec.mainClass="org.gephi.toolkit.demos.Main" -Dexec.cleanupDaemonThreads=false 
```

# known error

### java.lang.IllegalArgumentException: NaN is not a finite number

```
java.lang.IllegalArgumentException: NaN is not a finite number
        at org.apache.pdfbox.pdmodel.PDPageContentStream.writeOperand(PDPageContentStream.java:2453)
        at org.apache.pdfbox.pdmodel.PDPageContentStream.moveTo(PDPageContentStream.java:1757)
        at org.gephi.preview.plugin.renderers.ArrowRenderer.render(ArrowRenderer.java:133)
        at org.gephi.preview.PreviewControllerImpl.render(PreviewControllerImpl.java:236)
        at org.gephi.preview.PreviewControllerImpl.render(PreviewControllerImpl.java:190)
        at org.gephi.io.exporter.preview.PDFExporter.execute(PDFExporter.java:118)
        at org.gephi.io.exporter.impl.ExportControllerImpl.exportFile(ExportControllerImpl.java:117)
        at org.gephi.io.exporter.impl.ExportControllerImpl.exportFile(ExportControllerImpl.java:92)
        at org.gephi.toolkit.demos.PartitionGraph.script(PartitionGraph.java:110)
        at org.gephi.toolkit.demos.Main.main(Main.java:37)
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

However, normal pdfs are generated.

###  module java.base does not "opens java.net" 

java resouce access error.

This error can be resolved by setting the following environment variables　->  `JDK_JAVA_OPTIONS="--add-opens=java.base/java.net=ALL-UNNAMED"`

```
SEVERE: No way to find original stream handler for jar protocol
java.lang.reflect.InaccessibleObjectException: Unable to make field transient java.net.URLStreamHandler java.net.URL.handler accessible: module java.base does not "opens java.net" to unnamed module @4a59fb8a
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
        at org.netbeans.ProxyURLStreamHandlerFactory.register(ProxyURLStreamHandlerFactory.java:59)
        at org.netbeans.core.startup.Main.initializeURLFactory(Main.java:80)
        at org.netbeans.core.startup.NbRepository.<clinit>(NbRepository.java:47)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
``` 